### PR TITLE
Issue 54

### DIFF
--- a/optvm/src/main/java/com/compilerprogramming/ezlang/compiler/ExitSSA.java
+++ b/optvm/src/main/java/com/compilerprogramming/ezlang/compiler/ExitSSA.java
@@ -245,6 +245,13 @@ public class ExitSSA {
     private void addMoveAtBBEnd(BasicBlock block, Register src, Register dest) {
         var inst = new Instruction.Move(new Operand.RegisterOperand(src), new Operand.RegisterOperand(dest));
         insertAtEnd(block, inst);
+        // If the copy instruction is followed by a cbr which uses the old var
+        // then we need to update the cbr instruction
+        // This is not specified in the Briggs paper but t
+        var brInst = block.instructions.getLast();
+        if (brInst instanceof Instruction.ConditionalBranch cbr) {
+            cbr.replaceUse(src,dest);
+        }
     }
     /* Insert a copy from constant src to dst at end of BB */
     private void addMoveAtBBEnd(BasicBlock block, Operand.ConstantOperand src, Register dest) {

--- a/optvm/src/test/java/com/compilerprogramming/ezlang/compiler/TestSSATransform.java
+++ b/optvm/src/test/java/com/compilerprogramming/ezlang/compiler/TestSSATransform.java
@@ -3156,7 +3156,7 @@ L2:
     if %t2_0 goto L3 else goto L4
 L3:
     p_5 = p_1
-    if p_1 goto L5 else goto L6
+    if p_5 goto L5 else goto L6
 L5:
     %t3_0 = p_1+1
     p_4 = %t3_0


### PR DESCRIPTION
If a cbr instruction follows a copy instruction created due to ph removal, then update the cbr instruction to use the replacement